### PR TITLE
[libgsupplicant] Silence KeyMgmt SAE not known warning. JB#59693

### DIFF
--- a/src/gsupplicant_util.c
+++ b/src/gsupplicant_util.c
@@ -183,7 +183,9 @@ gsupplicant_parse_bits_array(
                     g_string_append(buf, str);
                 }
 #endif
-            } else {
+            } else if (g_strcmp0(name, "KeyMgmt") || g_strcmp0(str, "sae")) {
+                /* FIXME: just silencing the SAE case for now as it's known but not supported.
+                   Should implement proper mapping and support */
                 GWARN("Unexpected %s value %s", name, str);
             }
         }


### PR DESCRIPTION
Possibly do mapping for the mode, but since nothing would use that let's just silence the warning as simplest change.