### PR TITLE
Add WPA3 SAE and MFP support

### DIFF
--- a/include/gsupplicant.h
+++ b/include/gsupplicant.h
@@ -57,6 +57,7 @@ struct gsupplicant {
     const GStrV* interfaces;
     GSUPPLICANT_EAP_METHOD eap_methods;
     guint32 caps;
+    unsigned int wpa3_support;          /* Since 1.0.28 */
 
 #define GSUPPLICANT_CAPS_AP             (0x00000001)
 #define GSUPPLICANT_CAPS_IBSS_RSN       (0x00000002)
@@ -178,6 +179,12 @@ const char*
 gsupplicant_keymgmt_suite_name(
     guint keymgmt_suites,
     guint* keymgmt_suite);
+
+/* Since 1.0.28 */
+void
+gsupplicant_set_wpa3_support(
+    GSupplicant *supplicant,
+    GSUPPLICANT_WPA3_SUPPORT wpa3_support);
 
 #define gsupplicant_remove_all_handlers(supplicant, ids) \
     gsupplicant_remove_handlers(supplicant, ids, G_N_ELEMENTS(ids))

--- a/include/gsupplicant_interface.h
+++ b/include/gsupplicant_interface.h
@@ -194,6 +194,7 @@ typedef struct gsupplicant_network_params {
     const char* subject_match2;
     const char* altsubject_match2;
     const char* domain_suffix_match2;
+    GSUPPLICANT_KEYMGMT keymgmt;    /* Since 1.0.28 */
 } GSupplicantNetworkParams;
 
 typedef struct gsupplicant_wps_params {

--- a/include/gsupplicant_types.h
+++ b/include/gsupplicant_types.h
@@ -177,6 +177,17 @@ typedef struct gsupplicant_uint_array {
     guint count;
 } GSupplicantUIntArray;
 
+
+/*
+ * This is used to define the maximum level of WPA3 support that the
+ * device has. For convenience default to full.
+ */
+typedef enum gspupplicant_wpa3_support {            /* Since 1.0.28 */
+    GSUPPLICANT_WPA3_SUPPORT_FULL,
+    GSUPPLICANT_WPA3_SUPPORT_MIXED, /* Support only WPA2+WPA3 mixed */
+    GSUPPLICANT_WPA3_SUPPORT_NONE,
+} GSUPPLICANT_WPA3_SUPPORT;
+
 extern GLogModule GSUPPLICANT_LOG_MODULE;
 
 G_END_DECLS

--- a/include/gsupplicant_types.h
+++ b/include/gsupplicant_types.h
@@ -162,6 +162,8 @@ typedef enum gsupplicant_security {
     GSUPPLICANT_SECURITY_WEP,
     GSUPPLICANT_SECURITY_PSK,
     GSUPPLICANT_SECURITY_EAP,
+    GSUPPLICANT_SECURITY_PSK_SAE,
+    GSUPPLICANT_SECURITY_SAE,
 } GSUPPLICANT_SECURITY;
 
 typedef enum gsupplicant_mfp_options {

--- a/include/gsupplicant_types.h
+++ b/include/gsupplicant_types.h
@@ -164,6 +164,12 @@ typedef enum gsupplicant_security {
     GSUPPLICANT_SECURITY_EAP,
 } GSUPPLICANT_SECURITY;
 
+typedef enum gsupplicant_mfp_options {
+    GSUPPLICANT_MFP_NONE,
+    GSUPPLICANT_MFP_OPTIONAL,
+    GSUPPLICANT_MFP_REQUIRED,
+} GSUPPLICANT_MFP_OPTIONS;
+
 typedef struct gsupplicant_uint_array {
     const guint* values;
     guint count;

--- a/src/gsupplicant.c
+++ b/src/gsupplicant.c
@@ -897,6 +897,15 @@ gsupplicant_keymgmt_suite_name(
         gsupplicant_keymgmt_suites, G_N_ELEMENTS(gsupplicant_keymgmt_suites));
 }
 
+void
+gsupplicant_set_wpa3_support(
+    GSupplicant *supplicant,
+    GSUPPLICANT_WPA3_SUPPORT wpa3_support)
+{
+    if (supplicant)
+        supplicant->wpa3_support = wpa3_support;
+}
+
 /*==========================================================================*
  * Internal API
  *==========================================================================*/

--- a/src/gsupplicant_bss.c
+++ b/src/gsupplicant_bss.c
@@ -1272,15 +1272,26 @@ gsupplicant_bss_security(
     if (G_LIKELY(self) && self->valid && self->present) {
         GSUPPLICANT_KEYMGMT keymgmt = gsupplicant_bss_keymgmt(self);
         if (keymgmt & (GSUPPLICANT_KEYMGMT_WPA_EAP |
-                       GSUPPLICANT_KEYMGMT_WPA_FT_EAP |
-                       GSUPPLICANT_KEYMGMT_WPA_EAP_SHA256 |
-                       GSUPPLICANT_KEYMGMT_IEEE8021X)) {
+                        GSUPPLICANT_KEYMGMT_WPA_FT_EAP |
+                        GSUPPLICANT_KEYMGMT_WPA_EAP_SHA256 |
+                        GSUPPLICANT_KEYMGMT_IEEE8021X)) {
             return GSUPPLICANT_SECURITY_EAP;
         }
+        if (keymgmt & (GSUPPLICANT_KEYMGMT_SAE |
+                        GSUPPLICANT_KEYMGMT_SAE_EXT_KEY |
+                        GSUPPLICANT_KEYMGMT_FT_SAE |
+                        GSUPPLICANT_KEYMGMT_FT_SAE_EXT_KEY)) {
+            if (keymgmt & (GSUPPLICANT_KEYMGMT_WPA_PSK |
+                            GSUPPLICANT_KEYMGMT_WPA_FT_PSK |
+                            GSUPPLICANT_KEYMGMT_WPA_PSK_SHA256)) {
+                return GSUPPLICANT_SECURITY_PSK_SAE;
+            } else {
+                return GSUPPLICANT_SECURITY_SAE;
+            }
+        }
         if (keymgmt & (GSUPPLICANT_KEYMGMT_WPA_PSK |
-                       GSUPPLICANT_KEYMGMT_WPA_FT_PSK |
-                       GSUPPLICANT_KEYMGMT_WPA_PSK_SHA256 |
-                       GSUPPLICANT_KEYMGMT_SAE)) {
+                        GSUPPLICANT_KEYMGMT_WPA_FT_PSK |
+                        GSUPPLICANT_KEYMGMT_WPA_PSK_SHA256)) {
             return GSUPPLICANT_SECURITY_PSK;
         }
         if (self->privacy) {

--- a/src/gsupplicant_bss.c
+++ b/src/gsupplicant_bss.c
@@ -282,6 +282,7 @@ gsupplicant_bss_fill_network_params(
     np->subject_match2 = cp->subject_match2;
     np->altsubject_match2 = cp->altsubject_match2;
     np->domain_suffix_match2 = cp->domain_suffix_match2;
+    np->keymgmt = gsupplicant_bss_keymgmt(bss);
 }
 
 static inline
@@ -1278,7 +1279,8 @@ gsupplicant_bss_security(
         }
         if (keymgmt & (GSUPPLICANT_KEYMGMT_WPA_PSK |
                        GSUPPLICANT_KEYMGMT_WPA_FT_PSK |
-                       GSUPPLICANT_KEYMGMT_WPA_PSK_SHA256)) {
+                       GSUPPLICANT_KEYMGMT_WPA_PSK_SHA256 |
+                       GSUPPLICANT_KEYMGMT_SAE)) {
             return GSUPPLICANT_SECURITY_PSK;
         }
         if (self->privacy) {

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -385,6 +385,15 @@ gsupplicant_interface_emit_pending_signals(
 
 static
 void
+gsupplicant_interface_add_network_args_ieee80211w(
+    GVariantBuilder* builder,
+    GSUPPLICANT_MFP_OPTIONS ieee80211w)
+{
+    gsupplicant_dict_add_uint32(builder, "ieee80211w", ieee80211w);
+}
+
+static
+void
 gsupplicant_interface_add_network_args_security_wep(
     GVariantBuilder* builder,
     const GSupplicantNetworkParams* np)
@@ -651,8 +660,29 @@ gsupplicant_interface_add_network_args_new(
         gsupplicant_interface_add_network_args_security_ciphers(&builder, np);
         break;
     case GSUPPLICANT_SECURITY_PSK:
-        GDEBUG_("PSK security");
-        key_mgmt = "WPA-PSK";
+        GDEBUG_("PSK security np->keymgmt %d", np->keymgmt);
+        if (np->keymgmt & GSUPPLICANT_KEYMGMT_SAE) {
+            GDEBUG_("GSUPPLICANT_KEYMGMT_SAE");
+            GSUPPLICANT_MFP_OPTIONS ieee80211w;
+            if (np->keymgmt & GSUPPLICANT_KEYMGMT_WPA_PSK) {
+                GDEBUG_("GSUPPLICANT_KEYMGMT_WPA_PSK");
+                /*
+                 * WPA3-Personal transition mode: supports both
+                 * WPA2-Personal (PSK) and WPA3-Personal (SAE)
+                 */
+                key_mgmt = "SAE WPA-PSK";
+                ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
+            } else {
+                GDEBUG_("no GSUPPLICANT_KEYMGMT_WPA_PSK");
+                key_mgmt = "SAE";
+                ieee80211w = GSUPPLICANT_MFP_REQUIRED;
+            }
+            gsupplicant_interface_add_network_args_ieee80211w(&builder,
+                    ieee80211w);
+        } else {
+            key_mgmt = "WPA-PSK";
+        }
+        GDEBUG_(" GSUPPLICANT_SECURITY_PSK key_mgmt %s", key_mgmt);
         gsupplicant_interface_add_network_args_security_psk(&builder, np);
         gsupplicant_interface_add_network_args_security_proto(&builder, np);
         gsupplicant_interface_add_network_args_security_ciphers(&builder, np);

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -659,7 +659,13 @@ gsupplicant_interface_add_network_args_new(
         gsupplicant_interface_add_network_args_security_wep(&builder, np);
         gsupplicant_interface_add_network_args_security_ciphers(&builder, np);
         break;
+    /*
+     * Maintain compatibility when roaming between WPA2, WPA2/WPA3 and WPA3
+     * networks by handling all cases the same way.
+     */
     case GSUPPLICANT_SECURITY_PSK:
+    case GSUPPLICANT_SECURITY_PSK_SAE:
+    case GSUPPLICANT_SECURITY_SAE:
         GDEBUG_("PSK security np->keymgmt %d", np->keymgmt);
         GSUPPLICANT_MFP_OPTIONS ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
         key_mgmt = "SAE WPA-PSK WPA-PSK-SHA256";

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -661,28 +661,9 @@ gsupplicant_interface_add_network_args_new(
         break;
     case GSUPPLICANT_SECURITY_PSK:
         GDEBUG_("PSK security np->keymgmt %d", np->keymgmt);
-        if (np->keymgmt & GSUPPLICANT_KEYMGMT_SAE) {
-            GDEBUG_("GSUPPLICANT_KEYMGMT_SAE");
-            GSUPPLICANT_MFP_OPTIONS ieee80211w;
-            if (np->keymgmt & GSUPPLICANT_KEYMGMT_WPA_PSK) {
-                GDEBUG_("GSUPPLICANT_KEYMGMT_WPA_PSK");
-                /*
-                 * WPA3-Personal transition mode: supports both
-                 * WPA2-Personal (PSK) and WPA3-Personal (SAE)
-                 */
-                key_mgmt = "SAE WPA-PSK";
-                ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
-            } else {
-                GDEBUG_("no GSUPPLICANT_KEYMGMT_WPA_PSK");
-                key_mgmt = "SAE";
-                ieee80211w = GSUPPLICANT_MFP_REQUIRED;
-            }
-            gsupplicant_interface_add_network_args_ieee80211w(&builder,
-                    ieee80211w);
-        } else {
-            key_mgmt = "WPA-PSK";
-        }
-        GDEBUG_(" GSUPPLICANT_SECURITY_PSK key_mgmt %s", key_mgmt);
+        GSUPPLICANT_MFP_OPTIONS ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
+        key_mgmt = "SAE WPA-PSK WPA-PSK-SHA256";
+        gsupplicant_interface_add_network_args_ieee80211w(&builder, ieee80211w);
         gsupplicant_interface_add_network_args_security_psk(&builder, np);
         gsupplicant_interface_add_network_args_security_proto(&builder, np);
         gsupplicant_interface_add_network_args_security_ciphers(&builder, np);

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -632,12 +632,16 @@ gsupplicant_interface_add_network_args_security_proto(
 static
 GVariant*
 gsupplicant_interface_add_network_args_new(
+    const GSupplicantInterface *iface,
     const GSupplicantNetworkParams* np,
     GHashTable* blobs)
 {
     const char* key_mgmt = NULL;
     const char* auth_alg = NULL;
     GVariantBuilder builder;
+    GSUPPLICANT_WPA3_SUPPORT wpa3_support = GSUPPLICANT_WPA3_SUPPORT_FULL;
+    if (iface && iface->supplicant)
+        wpa3_support = iface->supplicant->wpa3_support;
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
     gsupplicant_dict_add_bytes0(&builder, "ssid", np->ssid);
     if (np->frequency) {
@@ -667,9 +671,17 @@ gsupplicant_interface_add_network_args_new(
     case GSUPPLICANT_SECURITY_PSK_SAE:
     case GSUPPLICANT_SECURITY_SAE:
         GDEBUG_("PSK security np->keymgmt %d", np->keymgmt);
-        GSUPPLICANT_MFP_OPTIONS ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
-        key_mgmt = "SAE WPA-PSK WPA-PSK-SHA256";
-        gsupplicant_interface_add_network_args_ieee80211w(&builder, ieee80211w);
+        // Fully supported or WPA2+WPA3 Mixed
+        if (wpa3_support == GSUPPLICANT_WPA3_SUPPORT_FULL ||
+                wpa3_support == GSUPPLICANT_WPA3_SUPPORT_MIXED) {
+            GSUPPLICANT_MFP_OPTIONS ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
+            key_mgmt = "SAE WPA-PSK WPA-PSK-SHA256";
+            gsupplicant_interface_add_network_args_ieee80211w(&builder,
+                ieee80211w);
+        // Not supported, GSUPPLICANT_WPA3_SUPPORT_NONE
+        } else {
+            key_mgmt = "WPA-PSK WPA-PSK-SHA256";
+        }
         gsupplicant_interface_add_network_args_security_psk(&builder, np);
         gsupplicant_interface_add_network_args_security_proto(&builder, np);
         gsupplicant_interface_add_network_args_security_ciphers(&builder, np);
@@ -1296,7 +1308,8 @@ gsupplicant_interface_add_network_call_new(
         call->blobs = g_hash_table_ref(blobs);
         g_hash_table_iter_init(&call->iter, call->blobs);
     }
-    call->args = gsupplicant_interface_add_network_args_new(np, call->blobs);
+    call->args = gsupplicant_interface_add_network_args_new(iface, np,
+        call->blobs);
     call->iface = gsupplicant_interface_ref(iface);
     call->fn = fn;
     call->destroy = destroy;

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -671,8 +671,11 @@ gsupplicant_interface_add_network_args_new(
     case GSUPPLICANT_SECURITY_PSK_SAE:
     case GSUPPLICANT_SECURITY_SAE:
         GDEBUG_("PSK security np->keymgmt %d", np->keymgmt);
-        // Fully supported or WPA2+WPA3 Mixed
-        if (wpa3_support == GSUPPLICANT_WPA3_SUPPORT_FULL ||
+        // Force WPA2 for now for all in AP mode ignoring WPA3 support level
+        if (np->mode == GSUPPLICANT_OP_MODE_AP) {
+            key_mgmt = "WPA-PSK";
+        // Fully supported or WPA2+WPA3 Mixed in non-AP mode
+        } else if (wpa3_support == GSUPPLICANT_WPA3_SUPPORT_FULL ||
                 wpa3_support == GSUPPLICANT_WPA3_SUPPORT_MIXED) {
             GSUPPLICANT_MFP_OPTIONS ieee80211w = GSUPPLICANT_MFP_OPTIONAL;
             key_mgmt = "SAE WPA-PSK WPA-PSK-SHA256";


### PR DESCRIPTION
Add support for WPA3 SAE. Support MFP (Management frame protection) but because of Wi-Fi certification requirements use always the OPTIONAL setting because roaming between different security types would otherwise break., see https://git.kernel.org/pub/scm/network/connman/connman.git/commit/gsupplicant/supplicant.c?id=5e73b55e00b97e1867397258b72f0d6e5ad7d31d