### PR TITLE
Add sae_pwe and sae_check_mfp to network parameters.

### DIFF
--- a/include/gsupplicant_interface.h
+++ b/include/gsupplicant_interface.h
@@ -70,7 +70,9 @@ typedef enum gsupplicant_interface_property {
     GSUPPLICANT_INTERFACE_PROPERTY_NETWORKS,
     GSUPPLICANT_INTERFACE_PROPERTY_SCAN_INTERVAL,
     GSUPPLICANT_INTERFACE_PROPERTY_STATIONS,        /* Since 1.0.7 */
-    GSUPPLICANT_INTERFACE_PROPERTY_COUNT
+    GSUPPLICANT_INTERFACE_PROPERTY_SAE_CHECK_MFP,   /* Since 1.0.29 */
+    GSUPPLICANT_INTERFACE_PROPERTY_SAE_PWE,         /* Since 1.0.29 */
+    GSUPPLICANT_INTERFACE_PROPERTY_COUNT,
 } GSUPPLICANT_INTERFACE_PROPERTY;
 
 typedef enum gsupplicant_interface_eap_event {
@@ -238,6 +240,8 @@ struct gsupplicant_interface {
     const GStrV* bsss;
     const GStrV* networks;
     const GStrV* stations;          /* Since 1.0.7 */
+    gboolean sae_check_mfp;             /* Since 1.0.29 */
+    GSUPPLICANT_SAE_PWE_OPTION sae_pwe; /* Since 1.0.29 */
 };
 
 typedef
@@ -498,6 +502,12 @@ gsupplicant_interface_add_eap_status_handler(
 GSUPPLICANT_INLINE const char*
 gsupplicant_interface_get_state_name(GSupplicantInterface* iface)
     { return iface ? gsupplicant_interface_state_name(iface->state) : NULL; }
+
+void gsupplicant_interface_set_sae_check_mfp(GSupplicantInterface *iface,
+    gboolean enable); /* Since: 1.0.29 */
+
+void gsupplicant_interface_set_sae_pwe(GSupplicantInterface* iface,
+    GSUPPLICANT_SAE_PWE_OPTION option); /* Since: 1.0.29 */
 
 #define gsupplicant_interface_remove_all_handlers(iface, ids) \
     gsupplicant_interface_remove_handlers(iface, ids, G_N_ELEMENTS(ids))

--- a/include/gsupplicant_types.h
+++ b/include/gsupplicant_types.h
@@ -172,6 +172,13 @@ typedef enum gsupplicant_mfp_options {
     GSUPPLICANT_MFP_REQUIRED,
 } GSUPPLICANT_MFP_OPTIONS;
 
+typedef enum gsupplicant_sae_pwe_option {
+    GSUPPLICANT_SAE_PWE_HNP,            /* Hunt-and-peck, the default */
+    GSUPPLICANT_SAE_PWE_H2E,            /* Hash-to-element */
+    GSUPPLICANT_SAE_PWE_BOTH,           /* HnP + H2E */
+    GSUPPLICANT_SAE_PWE_BOTH_FORCE,     /* Force use of HnP + H2E */
+} GSUPPLICANT_SAE_PWE_OPTION;
+
 typedef struct gsupplicant_uint_array {
     const guint* values;
     guint count;

--- a/spec/fi.w1.wpa_supplicant1.Interface.xml
+++ b/spec/fi.w1.wpa_supplicant1.Interface.xml
@@ -143,6 +143,8 @@
     <property name="PKCS11EnginePath" type="s" access="read"/>
     <property name="PKCS11ModulePath" type="s" access="read"/>
     <property name="DisconnectReason" type="i" access="read"/>
+    <property name="SaeCheckMfp" type="s" access="readwrite"/>
+    <property name="SaePwe" type="s" access="readwrite"/>
     <!--
     <property name="AssocStatusCode" type="i" access="read"/>
     <property name="CtrlInterface" type="s" access="readwrite"/>

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -153,6 +153,8 @@ enum supplicant_interface_proxy_handler_id {
     PROXY_NOTIFY_CURRENT_NETWORK,
     PROXY_NOTIFY_BSSS,
     PROXY_NOTIFY_NETWORKS,
+    PROXY_NOTIFY_SAE_CHECK_MFP,
+    PROXY_NOTIFY_SAE_PWE,
     PROXY_EAP,
     PROXY_HANDLER_COUNT
 };
@@ -180,6 +182,8 @@ struct gsupplicant_interface_priv {
     char* bridge_ifname;
     char* current_bss;
     char* current_network;
+    gboolean sae_check_mfp;
+    GSUPPLICANT_SAE_PWE_OPTION sae_pwe;
 };
 
 typedef GObjectClass GSupplicantInterfaceClass;
@@ -207,7 +211,9 @@ G_DEFINE_TYPE(GSupplicantInterface, gsupplicant_interface, G_TYPE_OBJECT)
     p(BSSS,bsss) \
     p(NETWORKS,networks) \
     p(SCAN_INTERVAL,scan-interval) \
-    p(STATIONS,stations)
+    p(STATIONS,stations) \
+    p(SAE_CHECK_MFP,sae-check-mfp) \
+    p(SAE_PWE,sae-pwe)
 
 typedef enum gsupplicant_interface_signal {
 #define SIGNAL_ENUM_(P,p) SIGNAL_##P##_CHANGED,
@@ -270,6 +276,8 @@ G_STATIC_ASSERT(G_N_ELEMENTS(gsupplicant_interface_signame) == SIGNAL_COUNT);
 #define PROXY_PROPERTY_NAME_PKCS11_ENGINE_PATH  "PKCS11EnginePath"
 #define PROXY_PROPERTY_NAME_PKCS11_MODULE_PATH  "PKCS11ModulePath"
 #define PROXY_PROPERTY_NAME_DISCONNECT_REASON   "DisconnectReason"
+#define PROXY_PROPERTY_NAME_SAE_CHECK_MFP       "SaeCheckMfp"
+#define PROXY_PROPERTY_NAME_SAE_PWE             "SaePwe"
 
 /* Weak references to the instances of GSupplicantInterface */
 static GHashTable* gsupplicant_interface_table = NULL;
@@ -1794,6 +1802,60 @@ gsupplicant_interface_update_networks(
 #endif
 }
 
+
+static
+void
+gsupplicant_interface_update_sae_check_mfp(
+    GSupplicantInterface* self)
+{
+    GSupplicantInterfacePriv* priv = self->priv;
+    const char *value_str =
+        fi_w1_wpa_supplicant1_interface_get_sae_check_mfp(priv->proxy);
+    gboolean value = g_strcmp0(value_str, "0") ? TRUE : FALSE;
+
+    if (priv->sae_check_mfp != value) {
+        self->sae_check_mfp = priv->sae_check_mfp = value;
+        priv->pending_signals |= SIGNAL_BIT(SAE_CHECK_MFP);
+        GVERBOSE("[%s] %s: %d", priv->path, PROXY_PROPERTY_NAME_SAE_CHECK_MFP,
+            self->sae_check_mfp);
+    }
+}
+
+static
+void
+gsupplicant_interface_update_sae_pwe(
+    GSupplicantInterface* self)
+{
+    GSupplicantInterfacePriv* priv = self->priv;
+    const char* value_str =
+        fi_w1_wpa_supplicant1_interface_get_sae_pwe(priv->proxy);
+    gchar *endptr = NULL;
+    guint value;
+
+    value = g_ascii_strtoull(value_str, &endptr, 10);
+    if (!value) {
+        /* Out of base or string conversion fails*/
+        if (errno == 0 && endptr != value_str) {
+            GVERBOSE("[%s] %s: failed to convert %s, default to HnP (0)",
+                priv->path, PROXY_PROPERTY_NAME_SAE_PWE, value_str);
+        }  
+    }
+
+    /* Not set or too big, default to GSUPPLICANT_SAE_PWE_HNP */
+    if (value > GSUPPLICANT_SAE_PWE_BOTH_FORCE) {
+        GVERBOSE("[%s] %s: value too big %u, default to HnP (0)",
+            priv->path, PROXY_PROPERTY_NAME_SAE_PWE, value);
+        value = GSUPPLICANT_SAE_PWE_HNP;
+    }
+
+    if (priv->sae_pwe != value) {
+        self->sae_pwe = priv->sae_pwe = (GSUPPLICANT_SAE_PWE_OPTION)value;
+        priv->pending_signals |= SIGNAL_BIT(SAE_PWE);
+        GVERBOSE("[%s] %s: %u", priv->path, PROXY_PROPERTY_NAME_SAE_PWE,
+            self->sae_pwe);
+    }
+}
+
 static
 void
 gsupplicant_interface_notify_state(
@@ -1949,6 +2011,31 @@ gsupplicant_interface_notify_networks(
     gsupplicant_interface_update_networks(self);
     gsupplicant_interface_emit_pending_signals(self);
 }
+
+static
+void
+gsupplicant_interface_notify_sae_check_mfp(
+    FiW1Wpa_supplicant1Interface* proxy,
+    GParamSpec* param,
+    gpointer data)
+{
+    GSupplicantInterface* self = GSUPPLICANT_INTERFACE(data);
+    gsupplicant_interface_update_sae_check_mfp(self);
+    gsupplicant_interface_emit_pending_signals(self);
+}
+
+static
+void
+gsupplicant_interface_notify_sae_pwe(
+    FiW1Wpa_supplicant1Interface* proxy,
+    GParamSpec* param,
+    gpointer data)
+{
+    GSupplicantInterface* self = GSUPPLICANT_INTERFACE(data);
+    gsupplicant_interface_update_sae_pwe(self);
+    gsupplicant_interface_emit_pending_signals(self);
+}
+
 
 static
 void
@@ -2233,6 +2320,12 @@ gsupplicant_interface_create2(
         priv->proxy_handler_id[PROXY_NOTIFY_NETWORKS] =
             g_signal_connect(priv->proxy, "notify::networks",
             G_CALLBACK(gsupplicant_interface_notify_networks), self);
+        priv->proxy_handler_id[PROXY_NOTIFY_SAE_CHECK_MFP] =
+            g_signal_connect(priv->proxy, "notify::sae-check-mfp",
+            G_CALLBACK(gsupplicant_interface_notify_sae_check_mfp), self);
+        priv->proxy_handler_id[PROXY_NOTIFY_SAE_PWE] =
+            g_signal_connect(priv->proxy, "notify::sae-pwe",
+            G_CALLBACK(gsupplicant_interface_notify_sae_pwe), self);
         priv->proxy_handler_id[PROXY_EAP] =
             g_signal_connect(priv->proxy, "eap",
             G_CALLBACK(gsupplicant_interface_proxy_eap), self);
@@ -2261,6 +2354,8 @@ gsupplicant_interface_create2(
         gsupplicant_interface_update_current_network(self);
         gsupplicant_interface_update_bsss(self);
         gsupplicant_interface_update_networks(self);
+        gsupplicant_interface_update_sae_check_mfp(self);
+        gsupplicant_interface_update_sae_pwe(self);
 
         gsupplicant_interface_emit_pending_signals(self);
     } else {
@@ -3170,6 +3265,21 @@ gsupplicant_interface_add_eap_status_handler(
 {
     return G_LIKELY(self) ? g_signal_connect(self, SIGNAL_EAP_NAME,
         G_CALLBACK(fn), data) :  0;
+}
+
+void gsupplicant_interface_set_sae_check_mfp(GSupplicantInterface *self,
+    gboolean enable) /* Since: 1.0.29 */
+{
+    fi_w1_wpa_supplicant1_interface_set_sae_check_mfp(self->priv->proxy,
+        enable ? "1" : "0");
+}
+
+void gsupplicant_interface_set_sae_pwe(GSupplicantInterface* self,
+    GSUPPLICANT_SAE_PWE_OPTION option)  /* Since: 1.0.29 */
+{
+    gchar *value = g_strdup_printf("%u", option);
+    fi_w1_wpa_supplicant1_interface_set_sae_pwe(self->priv->proxy, value);
+    g_free(value);
 }
 
 /*==========================================================================*


### PR DESCRIPTION
Support defining sae_pwe to have HnP, H2E or both, also in forced mode selectable for a network as Password-to-Element method.

Add also MFP option to select whether to limit SAE when PMF is not enabled (1 or above). By default this is off (0).