### PR TITLE
Drop SAE PWE both force option

### DIFF
--- a/include/gsupplicant_types.h
+++ b/include/gsupplicant_types.h
@@ -176,7 +176,6 @@ typedef enum gsupplicant_sae_pwe_option {
     GSUPPLICANT_SAE_PWE_HNP,            /* Hunt-and-peck, the default */
     GSUPPLICANT_SAE_PWE_H2E,            /* Hash-to-element */
     GSUPPLICANT_SAE_PWE_BOTH,           /* HnP + H2E */
-    GSUPPLICANT_SAE_PWE_BOTH_FORCE,     /* Force use of HnP + H2E */
 } GSUPPLICANT_SAE_PWE_OPTION;
 
 typedef struct gsupplicant_uint_array {

--- a/src/gsupplicant_interface.c
+++ b/src/gsupplicant_interface.c
@@ -1842,7 +1842,7 @@ gsupplicant_interface_update_sae_pwe(
     }
 
     /* Not set or too big, default to GSUPPLICANT_SAE_PWE_HNP */
-    if (value > GSUPPLICANT_SAE_PWE_BOTH_FORCE) {
+    if (value > GSUPPLICANT_SAE_PWE_BOTH) {
         GVERBOSE("[%s] %s: value too big %u, default to HnP (0)",
             priv->path, PROXY_PROPERTY_NAME_SAE_PWE, value);
         value = GSUPPLICANT_SAE_PWE_HNP;


### PR DESCRIPTION
This is enabled only in testing mode of wpa_supplicant. Not used with production versions by default. Drop it from the enum.